### PR TITLE
Added path to dist version in "main" of bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,10 @@
     }
   ],
   "description": "A simple Emoji picker for AngularJS",
-  "main": [],
+  "main": [
+    "dist/js/emoji-picker.js",
+    "dist/css/emoji-picker.css"
+  ],
   "dependencies": {
     "angular": "1.3.x",
     "angular-sanitize": "1.3.x"


### PR DESCRIPTION
Having "main" filled out in bower.json allows Wiredep to automatically inject dependencies into a project (I.e., the yeoman/generator-angular workflow).